### PR TITLE
fix: django 4.x removed smart_text

### DIFF
--- a/puppeteer_pdf/utils.py
+++ b/puppeteer_pdf/utils.py
@@ -9,7 +9,7 @@ from itertools import chain
 from tempfile import NamedTemporaryFile
 
 from django.core.files import File
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
 try:
     from urllib.request import pathname2url
@@ -276,7 +276,7 @@ def render_to_temporary_file(template, context, request=None, mode='w+b',
     except AttributeError:
         content = loader.render_to_string(template, context)
 
-    content = smart_text(content)
+    content = smart_str(content)
     content = make_absolute_paths(content)
 
     try:


### PR DESCRIPTION
Django 4.x removed `django.utils.encoding.smart_text` - simple replacement with `smart_str` instead.